### PR TITLE
Imagehelper addition

### DIFF
--- a/model/NotebookImageHelper.py
+++ b/model/NotebookImageHelper.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+import sys
+
+import numpy
+
+from osgeo import gdal
+
+
+# ----------------------------------------------------------------------------
+# Class NotebookImageHelper
+#
+# TODO: add accessors using @property.
+# ----------------------------------------------------------------------------
+class NotebookImageHelper(object):
+
+    # ------------------------------------------------------------------------
+    # init
+    # ------------------------------------------------------------------------
+    def __init__(self):
+
+        self._dataset: gdal.Dataset = None
+        self._inputFile: Path = None
+        self._redBandId: int = 1
+        self._greenBandId: int = 1
+        self._blueBandId: int = 1
+        self._redBand: numpy.ndarray = None
+        self._greenBand: numpy.ndarray = None
+        self._blueBand: numpy.ndarray = None
+        self._noDataValue: float = -9999.0
+        self._minValue: float = sys.float_info.max
+        self._maxValue: float = sys.float_info.min
+
+    # ------------------------------------------------------------------------
+    # initFromDataset
+    # ------------------------------------------------------------------------
+    def initFromDataset(self,
+                        dataset: gdal.Dataset,
+                        noDataValue: float,
+                        redBandId: int = 1,
+                        greenBandId: int = 1,
+                        blueBandId: int = 1,
+                        ) -> None:
+
+        self._dataset = dataset
+
+        self._completeInitialization(noDataValue,
+                                     redBandId,
+                                     greenBandId,
+                                     blueBandId)
+
+    # ------------------------------------------------------------------------
+    # initFromFile
+    # ------------------------------------------------------------------------
+    def initFromFile(self,
+                     inputFile: Path,
+                     noDataValue: float,
+                     redBandId: int = 1,
+                     blueBandId: int = 1,
+                     greenBandId: int = 1,
+                     ) -> None:
+
+        # TODO: check validity and comment.
+        self._inputFile = inputFile
+        self._dataset: gdal.Dataset = gdal.Open(str(self._inputFile))
+
+        self._completeInitialization(noDataValue,
+                                     redBandId,
+                                     greenBandId,
+                                     blueBandId)
+
+    # ------------------------------------------------------------------------
+    # completeInitialization
+    # ------------------------------------------------------------------------
+    def _completeInitialization(self,
+                                noDataValue: float,
+                                redBandId: int = 1,
+                                greenBandId: int = 1,
+                                blueBandId: int = 1,
+                                ) -> None:
+
+        self._redBandId = redBandId
+        self._greenBandId = greenBandId
+        self._blueBandId = blueBandId
+
+        # Generate overviews, if they do not exist.
+        if self._dataset.GetRasterBand(1).GetOverviewCount() == 0:
+            _ = self. _dataset.BuildOverviews()
+
+        # ---
+        # Read the bands.
+        # ---
+        self._redBand: numpy.ndarray = \
+            self._dataset.GetRasterBand(self._redBandId).ReadAsArray()
+
+        self._greenBand: numpy.ndarray = \
+            self._dataset.GetRasterBand(self._greenBandId).ReadAsArray()
+
+        self._blueBand: numpy.ndarray = \
+            self._dataset.GetRasterBand(self._blueBandId).ReadAsArray()
+
+        # ---
+        # Initialize the no-data value.
+        # ---
+        self._noDataValue = self._dataset.GetRasterBand(self._redBandId). \
+            GetNoDataValue() or noDataValue
+
+        # ---
+        # Compute the minimum and maximum pixels values to help the renderer.
+        # ---
+        forExtremes = self._redBand[self._redBand != self._noDataValue]
+        self._minValue: float = forExtremes.min()
+        self._maxValue: float = forExtremes.max()
+
+    # ------------------------------------------------------------------------
+    # getCorners
+    #
+    # Why is this not built into gdal?
+    # ------------------------------------------------------------------------
+    def getCorners(self):
+
+        minx, xres, xskew, maxy, yskew, yres = \
+            self._dataset.GetGeoTransform()
+
+        maxx = minx + (self._dataset.RasterXSize * xres)
+        miny = maxy + (self._dataset.RasterYSize * yres)
+
+        return (minx, miny, maxx, maxy)
+
+    # ------------------------------------------------------------------------
+    # getRgbIndexList
+    # ------------------------------------------------------------------------
+    def getRgbIndexList(self) -> list:
+
+        return [self._redBandId, self._greenBandId, self._blueBandId]
+
+    # ------------------------------------------------------------------------
+    # getRgbBands
+    # ------------------------------------------------------------------------
+    def getRgbBands(self) -> list:
+
+        return [self._redBand, self._greenBand, self._blueBand]
+
+    # ------------------------------------------------------------------------
+    # __str__
+    # ------------------------------------------------------------------------
+    def __str__(self):
+
+        return ('Input file: ' + str(self._inputFile) +
+                '\nMin. pixel: ' + str(self._minValue) +
+                '\nMax. pixel: ' + str(self._maxValue) +
+                '\nNo-data value: ' + str(self._noDataValue) +
+                '\nRed band index: ' + str(self._redBandId) +
+                '\nGreen band index: ' + str(self._greenBandId) +
+                '\nBlue band index: ' + str(self._blueBandId) +
+                '\nCorners: ' + str(self.getCorners())
+                )

--- a/model/SystemCommand.py
+++ b/model/SystemCommand.py
@@ -39,7 +39,8 @@ class SystemCommand(object):
                                    shell=True,
                                    stderr=subprocess.PIPE,
                                    stdout=subprocess.PIPE,
-                                   close_fds=True)
+                                   close_fds=True,
+                                   executable='/bin/bash')
 
         self.returnCode = process.returncode
         stdOutStdErr = process.communicate()

--- a/model/tests/test_NotebookImageHelper.py
+++ b/model/tests/test_NotebookImageHelper.py
@@ -1,0 +1,112 @@
+import numpy as np
+from osgeo import gdal
+import unittest
+
+from core.model.NotebookImageHelper import NotebookImageHelper
+
+
+class NotebookImageHelperTests(unittest.TestCase):
+
+    def setUp(self):
+
+        # Create dummy numpy arrays for RGB bands
+        width = 100
+        height = 100
+
+        red_band = np.zeros((height, width), dtype=np.uint8)
+        green_band = np.ones((height, width), dtype=np.uint8)
+        blue_band = np.full((height, width), 255, dtype=np.uint8)
+
+        # Create an in-memory dataset
+        driver = gdal.GetDriverByName('MEM')
+
+        dataset = driver.Create('', width, height, 3, gdal.GDT_Byte)
+
+        dataset.GetRasterBand(1).WriteArray(red_band)
+        dataset.GetRasterBand(2).WriteArray(green_band)
+        dataset.GetRasterBand(3).WriteArray(blue_band)
+
+        self.dataset = dataset
+
+        self.noDataValue = -9999.0
+
+        self.redBandId = 1
+        self.greenBandId = 2
+        self.blueBandId = 3
+
+        self.helper = NotebookImageHelper()
+
+        self.helper.initFromDataset(
+            self.dataset,
+            self.noDataValue,
+            self.redBandId,
+            self.greenBandId,
+            self.blueBandId
+        )
+
+    def tearDown(self):
+
+        self.dataset = None
+
+        self.helper = None
+
+    def test_initFromDataset(self):
+
+        self.assertEqual(self.helper._dataset, self.dataset)
+
+        self.assertEqual(self.helper._noDataValue, self.noDataValue)
+
+        self.assertEqual(self.helper._redBandId, self.redBandId)
+
+        self.assertEqual(self.helper._greenBandId, self.greenBandId)
+
+        self.assertEqual(self.helper._blueBandId, self.blueBandId)
+
+        self.assertIsNotNone(self.helper._redBand)
+
+        self.assertIsNotNone(self.helper._greenBand)
+
+        self.assertIsNotNone(self.helper._blueBand)
+
+        self.assertEqual(self.helper._minValue, np.min(self.helper._redBand))
+
+        self.assertEqual(self.helper._maxValue, np.max(self.helper._redBand))
+
+    def test_getCorners(self):
+
+        corners = self.helper.getCorners()
+
+        self.assertIsInstance(corners, tuple)
+
+        self.assertEqual(len(corners), 4)
+
+    def test_getRgbIndexList(self):
+
+        rgbIndexList = self.helper.getRgbIndexList()
+
+        self.assertIsInstance(rgbIndexList, list)
+
+        self.assertEqual(len(rgbIndexList), 3)
+
+    def test_getRgbBands(self):
+
+        rgbBands = self.helper.getRgbBands()
+
+        self.assertIsInstance(rgbBands, list)
+
+        self.assertEqual(len(rgbBands), 3)
+
+    def test_str(self):
+
+        string = str(self.helper)
+
+        expectedString = 'Input file: ' + str(None) + \
+            '\nMin. pixel: ' + str(0) + \
+            '\nMax. pixel: ' + str(0) + \
+            '\nNo-data value: ' + str(-9999.0) + \
+            '\nRed band index: ' + str(1) + \
+            '\nGreen band index: ' + str(2) + \
+            '\nBlue band index: ' + str(3) + \
+            '\nCorners: ' + str((0.0, 100.0, 100.0, 0.0))
+
+        self.assertEqual(string, expectedString)


### PR DESCRIPTION
# Core - Adding NotebookImageHelper

## Description
ImageHelper was originally developed as a sub-module of the ImageCluster application. This sub-module is very useful for any application looking to render RGB satellite imagery in JupyterNotebooks. This PR adds the NotebookImageHelper class along with unit tests. 

## Testing

- [x] Added code passes PEP 8
- [x] Added unit tests pass

## Note
All unit tests do not pass (test_FootprintsQuery and test_DgFile have multiple unit tests that fail). A new issue will be created to address this, it would be out of scope for the PR.